### PR TITLE
Fix bypass mode not working

### DIFF
--- a/SCPSL-InventoryAccess/EventHandlers.cs
+++ b/SCPSL-InventoryAccess/EventHandlers.cs
@@ -17,12 +17,14 @@ namespace SCPSL_InventoryAccess
         public void OnPlayerDoorInteract(ref DoorInteractionEvent ev)
         {
             if (SCP_ROLES.Contains(ev.Player.GetRole())) return;
+            if (ev.Allow) return;
             ev.Allow = hasPermission(ev.Player, ev.Door.permissionLevel);
         }
 
         public void OnPlayerLockerInteract(LockerInteractionEvent ev)
         {
             if (SCP_ROLES.Contains(ev.Player.GetRole())) return;
+            if (ev.Allow) return;
             ev.Allow = hasPermission(ev.Player, ev.Locker.chambers[0].accessToken);
         }
 

--- a/SCPSL-InventoryAccess/EventHandlers.cs
+++ b/SCPSL-InventoryAccess/EventHandlers.cs
@@ -31,6 +31,7 @@ namespace SCPSL_InventoryAccess
         public void OnGeneratorAccess(ref GeneratorUnlockEvent ev)
         {
             if (SCP_ROLES.Contains(ev.Player.GetRole())) return;
+            if (ev.Allow) return;
             ev.Allow = hasPermission(ev.Player, "ARMORY_LVL_2");
         }
 


### PR DESCRIPTION
Changes the custom eventhandler to not check for permission if the game
already thinks the player is allowed to perform the interaction.

Fix #1